### PR TITLE
mmap done. 4 failed

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,6 +39,7 @@
         "inspect.h": "c",
         "round.h": "c",
         "memory_resource": "c",
-        "process.h": "c"
+        "process.h": "c",
+        "directory.h": "c"
     }
 }

--- a/pintos-kaist/include/userprog/syscall.h
+++ b/pintos-kaist/include/userprog/syscall.h
@@ -10,5 +10,6 @@ struct lock filesys_lock; // [*]2-K: 파일 시스템 락 추가
 
 void *sys_mmap(void *addr, size_t length, int writable, int fd, off_t offset);
 void sys_munmap(void *addr);
+void sys_close(int fd);
 
 #endif /* userprog/syscall.h */

--- a/pintos-kaist/userprog/syscall.c
+++ b/pintos-kaist/userprog/syscall.c
@@ -277,7 +277,7 @@ sys_close(int fd){
   
   lock_acquire(&filesys_lock);
   file_close(cur->fd_table[fd]);
-    lock_release(&filesys_lock);
+  lock_release(&filesys_lock);
 }
 
 //[*]3-L process.c와의 씽크를 위

--- a/pintos-kaist/vm/file.c
+++ b/pintos-kaist/vm/file.c
@@ -84,7 +84,7 @@ file_backed_swap_out (struct page *page) {
 
     // CHECK dirty page
     if(pml4_is_dirty(thread_current()->pml4, page->va)){
-        file_write_at(segment_aux->file, page->va, segment_aux->page_read_bytes, segment_aux->offset);
+        file_write_at(segment_aux->file, page->frame->kva, segment_aux->page_read_bytes, segment_aux->offset);
         pml4_set_dirty (thread_current()->pml4, page->va, 0);
     }
 
@@ -104,7 +104,7 @@ file_backed_destroy(struct page *page) {
 
 		// dirty 여부 확인 후 파일에 반영
 		if (pml4_is_dirty(thread_current()->pml4, page->va)) {
-			file_write_at(segment_aux->file, page->va, segment_aux->page_read_bytes, segment_aux->offset);
+			file_write_at(segment_aux->file, page->frame->kva, segment_aux->page_read_bytes, segment_aux->offset);
 			pml4_set_dirty(thread_current()->pml4, page->va, 0);
 		}
 	}
@@ -163,7 +163,7 @@ void do_munmap(void *addr) {
 
 
         if(pml4_is_dirty(thread_current()->pml4, page->va)) {
-            file_write_at(segment_aux->file, addr, segment_aux->page_read_bytes, segment_aux->offset); 
+            file_write_at(segment_aux->file, page->frame->kva, segment_aux->page_read_bytes, segment_aux->offset); 
             pml4_set_dirty (thread_current()->pml4, page->va, 0);
         }
 


### PR DESCRIPTION
## #️⃣ Issue Number

close # 

## 📝 요약(Summary)

mmap-exit 완료.
process_exit : 로직 순서, 
process_cleanup : VM 사용시 로직, 
file.c : do_munmap, file_backed_destroy, file_backed_swap_out에서 
          file_write_at 시 두번째 인자 page->frame->kva로 변경

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정


## 💬 공유사항 to 리뷰어

FAIL tests/vm/page-merge-par
FAIL tests/vm/page-merge-stk
FAIL tests/vm/page-merge-mm
FAIL tests/vm/cow/cow-simple

